### PR TITLE
ffmpeg 5 compatibility

### DIFF
--- a/demuxer.cpp
+++ b/demuxer.cpp
@@ -3,7 +3,9 @@
 #include <iostream>
 
 Demuxer::Demuxer(const std::string &file_name) {
+#if (LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 6, 102))
 	av_register_all();
+#endif
 	ffmpeg::check(avformat_open_input(
 		&format_context_, file_name.c_str(), nullptr, nullptr));
 

--- a/video_decoder.cpp
+++ b/video_decoder.cpp
@@ -3,7 +3,9 @@
 #include <string>
 
 VideoDecoder::VideoDecoder(AVCodecParameters* codec_parameters) {
+#if (LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 6, 102))
 	avcodec_register_all();
+#endif
 	const auto codec = avcodec_find_decoder(codec_parameters->codec_id);
 	if (!codec) {
 		throw ffmpeg::Error{"Unsupported video codec"};


### PR DESCRIPTION
`av_register_all()` / `avcodec_register_all()` were deprecated in ffmpeg 4 and [removed in ffmpeg 5](https://github.com/FFmpeg/FFmpeg/blob/70d25268c21cbee5f08304da95be1f647c630c15/doc/APIchanges#L86).