### PR TITLE
Add missed dependencies for Ubuntu in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ TrueType font rendering add on (libsdl2_ttf).
 On Debian GNU/Linux the required development packages can be installed via `apt`:
 
 ```sh
-apt install libavformat-dev libswscale-dev libsdl2-dev libsdl2-ttf-dev
+apt install libavformat-dev libavcodec-dev libavfilter-dev libavutil-dev libswscale-dev libsdl2-dev libsdl2-ttf-dev
 ```
 
 ### Instructions


### PR DESCRIPTION
There are some dependencies that we need to install before building in Ubuntu: libavcodec-dev libavfilter-dev libavutil-dev.