### PR TITLE
Fix a compilation error in string_utils.h

### DIFF
--- a/string_utils.h
+++ b/string_utils.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <cassert>
+#include <cstdint>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
With newer gcc versions the following error is thrown: ‘uint64_t’ does not name a type